### PR TITLE
[FIX] Fix undeclared identifier error with Lua 5.4+

### DIFF
--- a/Source/Registry/LuaCompiler.cpp
+++ b/Source/Registry/LuaCompiler.cpp
@@ -36,9 +36,11 @@ void inline _checkErrorAndThrow(LuaState &L, int error) {
 			case LUA_ERRMEM:
 				throw std::runtime_error("Out of memory");
 				break;
+#if LUA_VERSION_NUM < 504
 			case LUA_ERRGCMM:
 				throw std::out_of_range("GC Error while loading");
 				break;
+#endif
 			case LUA_ERRSYNTAX:
 				throw std::logic_error(lua_tostring(L,1));
 				break;

--- a/Source/UnitTest/TestLuaCompiler.cpp
+++ b/Source/UnitTest/TestLuaCompiler.cpp
@@ -75,7 +75,9 @@ namespace LuaCpp {
 		EXPECT_NO_THROW(_checkErrorAndThrow(*L, LUA_OK));
 		EXPECT_THROW(_checkErrorAndThrow(*L, LUA_ERRMEM), std::runtime_error);
 		lua_pushstring(*L, "some error");
+#if LUA_VERSION_NUM < 504
 		EXPECT_THROW(_checkErrorAndThrow(*L, LUA_ERRGCMM), std::out_of_range);
+#endif
 		EXPECT_THROW(_checkErrorAndThrow(*L, LUA_ERRSYNTAX), std::logic_error);
 
 		EXPECT_THROW(_checkErrorAndThrow(*L, 9999), std::runtime_error);


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
<!--- Name your PRs [FIX] for bug fixes and [IMP] for improvements -->
<!--- Break the changes in multiple PRs if the change is larger -->

## PR Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Change type
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Dependancies
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Introduced additional dependancies (ex. libraries, tools, etc.)

<!--- Add the list of PRs that this PR depends on -->

## Description

<!--- Describe your changes in detail -->
The LUA_ERRGCMM constant has been removed.
See: https://www.lua.org/manual/5.4/manual.html#8.3

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #4 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran unit tests with both Lua 5.4 and 5.3.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
