### PR TITLE
[IMP] Add possibility to pass a custom allocator

### DIFF
--- a/Source/Engine/LuaState.cpp
+++ b/Source/Engine/LuaState.cpp
@@ -32,6 +32,11 @@ LuaState::LuaState() {
 	L = luaL_newstate();
 }
 
+LuaState::LuaState(StateParams params) {
+   shared = false;
+   L = lua_newstate(params.allocator, params.userData);
+}
+
 LuaState::~LuaState() {
 	if (!shared) {
 		lua_close(L);

--- a/Source/Engine/LuaState.hpp
+++ b/Source/Engine/LuaState.hpp
@@ -37,6 +37,14 @@ namespace LuaCpp {
 	namespace Engine {
 
 		/**
+		 * @brief Parameters for creating a Lua state with a custom allocator
+		 */
+		struct StateParams final {
+			lua_Alloc allocator = nullptr;
+			void* userData = nullptr;
+		};
+
+		/**
 		 * @brief Wrapper of `struct lua_State` defined in the Lua library
 		 *
 		 * @details
@@ -59,6 +67,8 @@ namespace LuaCpp {
 			 * one the instance is destroyed.
 			 */
 			explicit LuaState();
+
+			explicit LuaState(StateParams params);
 
 			/**
 			 * @brief Constructor that creates a new state

--- a/Source/LuaContext.hpp
+++ b/Source/LuaContext.hpp
@@ -26,6 +26,7 @@
 #define LUACPP_LUACONTEXT_HPP
 
 #include <memory>
+#include <optional>
 
 #include "Registry/LuaRegistry.hpp"
 #include "Registry/LuaLibrary.hpp"
@@ -103,7 +104,7 @@ namespace LuaCpp {
 		 *
 		 * @return Pointer to the LuaState object holding the pointer of the lua_State
 		 */
-		std::unique_ptr<Engine::LuaState> newState();
+		std::unique_ptr<Engine::LuaState> newState(std::optional<Engine::StateParams> params = std::nullopt);
 
 		/**
 		 * @brief Creates new Lua execution state from the context
@@ -118,7 +119,7 @@ namespace LuaCpp {
 		 *
 		 * @return Pointer to the LuaState object holding the pointer of the lua_State
 		 */
-		std::unique_ptr<Engine::LuaState> newState(const LuaEnvironment &env);
+		std::unique_ptr<Engine::LuaState> newState(const LuaEnvironment &env, std::optional<Engine::StateParams> params = std::nullopt);
 
 		/**
 		 * @brief Creates new Lua execution state from the context and loads a snippet
@@ -140,7 +141,7 @@ namespace LuaCpp {
 		 *
 		 * @return Pointer to the LuaState object holding the pointer of the lua_State
 		 */
-	        std::unique_ptr<Engine::LuaState> newStateFor(const std::string &name);
+	        std::unique_ptr<Engine::LuaState> newStateFor(const std::string &name, std::optional<Engine::StateParams> params = std::nullopt);
 		
 		/**
 		 * @brief Creates new Lua execution state from the context and loads a snippet
@@ -162,7 +163,7 @@ namespace LuaCpp {
 		 *
 		 * @return Pointer to the LuaState object holding the pointer of the lua_State
 		 */
-	        std::unique_ptr<Engine::LuaState> newStateFor(const std::string &name, const LuaEnvironment &env);
+	        std::unique_ptr<Engine::LuaState> newStateFor(const std::string &name, const LuaEnvironment &env, std::optional<Engine::StateParams> params = std::nullopt);
 
 		/**
 		 * @brief Compiles a string containing Lua code and adds it to the repository
@@ -377,7 +378,7 @@ namespace LuaCpp {
 		 *
 		 * @param name Name under which the snippet is registered
 		 */
-		void RunWithEnvironment(const std::string &name, const LuaEnvironment &env);
+		void RunWithEnvironment(const std::string &name, const LuaEnvironment &env, std::optional<Engine::StateParams> params = std::nullopt);
 
 		/**
 		* @brief Get a LUA standard library


### PR DESCRIPTION
# PR Details

[IMP] Add possibility to pass a custom allocator

## PR Type

### Change type
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)

### Dependancies
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Introduced additional dependancies (ex. libraries, tools, etc.)

## Description

added a parameter for creating a Lua state in which you can pass
your own allocator to manage memory allocation in this state

## Motivation and Context

I would like to add the possibility of memory control during script execution

## How Has This Been Tested

https://github.com/miet-lambda/lambda-executor/blob/779d9ed0c9afcfdb3ae27d9477f002ba3ab48e1f/src/ut/lua-executor-ut.cpp#L634

## Checklist

- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
