### PR TITLE
Add support for C++ modules

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -284,3 +284,38 @@ if (DOXYGEN_FOUND)
 else (DOXYGEN_FOUND)
   message("Doxygen need to be installed to generate the doxygen documentation")
 endif (DOXYGEN_FOUND)
+
+##########
+# Modules
+##########
+option(LUACPP_BUILD_MODULES "Build C++ modules" OFF)
+
+if(LUACPP_BUILD_MODULES)
+    add_library(luacpp_module)
+
+    target_sources(luacpp_module
+        PUBLIC
+            FILE_SET CXX_MODULES FILES
+                LuaCpp.cppm
+    )
+
+    target_compile_features(luacpp_module PUBLIC cxx_std_20)
+
+    target_include_directories(luacpp_module PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>
+    )
+
+    target_link_libraries(luacpp_module PUBLIC ${LUA_LIBRARIES})
+
+    add_library(LuaCpp::module ALIAS luacpp_module)
+
+    # Installation
+    install(TARGETS luacpp_module
+        EXPORT LuaCppTargets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        FILE_SET CXX_MODULES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
+    )
+endif()

--- a/Source/LuaCpp.cppm
+++ b/Source/LuaCpp.cppm
@@ -1,0 +1,69 @@
+/*
+   MIT License
+
+   Copyright (c) 2021 Jordan Vrtanoski
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+   */
+
+module;
+
+#include <limits.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#include "LuaCpp.hpp"
+
+export module LuaCpp;
+
+export {
+    #include "Lua.hpp"
+}
+
+export namespace LuaCpp {
+    using LuaCpp::LuaEnvironment;
+    using LuaCpp::StateProxy;
+    using LuaCpp::LuaContext;
+    using LuaCpp::LuaMetaObject;
+
+    namespace Engine {
+        using LuaCpp::Engine::StateParams;
+        using LuaCpp::Engine::LuaState;
+        using LuaCpp::Engine::LuaType;
+        using LuaCpp::Engine::LuaTNil;
+        using LuaCpp::Engine::LuaTString;
+        using LuaCpp::Engine::LuaTBoolean;
+        using LuaCpp::Engine::LuaTNumber;
+        using LuaCpp::Engine::LuaTTable;
+        using LuaCpp::Engine::LuaTUserData;
+
+        namespace Table {
+            using LuaCpp::Engine::Table::Key;
+        }
+    }
+
+    namespace Registry {
+        using LuaCpp::Registry::LuaCompiler;
+        using LuaCpp::Registry::LuaRegistry;
+        using LuaCpp::Registry::LuaCodeSnippet;
+        using LuaCpp::Registry::LuaLibrary;
+        using LuaCpp::Registry::LuaCFunction;
+    }
+}


### PR DESCRIPTION
This PR adds support for building LuaCpp as a C++ module. It creates a module `LuaCpp` and exports the wrapper library itself and the raw C liblua in the global namespace.