### PR TITLE
FIX: Fix _checkErrorAndThrow linkage and declaration mismatch

### DIFF
--- a/Source/Registry/LuaCompiler.cpp
+++ b/Source/Registry/LuaCompiler.cpp
@@ -30,7 +30,7 @@
 using namespace LuaCpp::Registry;
 using namespace LuaCpp::Engine;
 
-void inline _checkErrorAndThrow(LuaState &L, int error) {
+void _checkErrorAndThrow(LuaState &L, int error) {
 	if (error != LUA_OK) {
 		switch (error) {
 			case LUA_ERRMEM:

--- a/Source/UnitTest/TestLuaCompiler.cpp
+++ b/Source/UnitTest/TestLuaCompiler.cpp
@@ -53,7 +53,7 @@ using namespace LuaCpp::Engine;
 using namespace LuaCpp::Registry;
 
 // Fixture for the test of the internal library function
-int _checkErrorAndThrow(LuaState &L, int error);
+void _checkErrorAndThrow(LuaState &L, int error);
 
 namespace LuaCpp {
 


### PR DESCRIPTION
Remove inline specifier from _checkErrorAndThrow so the symbol is exported for cross-TU linkage, and fix the return type in the test forward declaration from int to void to match the definition.

# PR Details

Fix of the linker instability

## PR Type

### Change type
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Dependencies
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Introduced additional dependencies (ex. libraries, tools, etc.)

## Description

The inline is causing some versions of gcc to throw "random" errors during linking. When marked inline, the compiler is permitted (and often will) omit emitting a globally-visible symbol for it, since inline signals that the definition may appear in multiple translation units and the linker should deduplicate. However, the unit test file (TestLuaCompiler.cpp) forward-declares this function and calls it directly from a different translation unit. With inline, the linker may fail to find the symbol (undefined reference), or it may only work by luck depending on the compiler/optimization level. Removing inline guarantees the function has external linkage and a symbol the linker can resolve from the test.
## Related Issue

## Motivation and Context

## How Has This Been Tested

Full unit test passing

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
