### PR TITLE
[FIX] Add bounds checking in LuaTTable::getValue and modernize NULL t…

### DIFF
--- a/Source/Engine/LuaTTable.cpp
+++ b/Source/Engine/LuaTTable.cpp
@@ -29,6 +29,7 @@
 #include "LuaTString.hpp"
 #include "LuaTNumber.hpp"
 #include "LuaTBoolean.hpp"
+#include "LuaTNil.hpp"
 
 using namespace LuaCpp::Engine;
 using namespace LuaCpp::Engine::Table;
@@ -204,7 +205,12 @@ std::map<Table::Key, std::shared_ptr<LuaType>> LuaTTable::getValues() const {
 }
 
 LuaType &LuaTTable::getValue(Table::Key key) {
-	return *table[key];
+	auto it = table.find(key);
+	if (it == table.end()) {
+		static LuaTNil nilPlaceholder;
+		return nilPlaceholder;
+	}
+	return *(it->second);
 }
 
 void LuaTTable::setValue(Table::Key key, std::shared_ptr<LuaType> value) {

--- a/Source/Engine/LuaTUserData.hpp
+++ b/Source/Engine/LuaTUserData.hpp
@@ -96,7 +96,7 @@ namespace LuaCpp {
 			 * size of the buffer that should be allocated to hold the
 			 * user data in the `lua` context.
 			 */
-			explicit LuaTUserData(size_t _size) : LuaType(), userdata(NULL), size(_size), metatable() {}
+			explicit LuaTUserData(size_t _size) : LuaType(), userdata(nullptr), size(_size), metatable() {}
 			
 			/**
 			 * @brief Default destructor

--- a/Source/LuaContext.cpp
+++ b/Source/LuaContext.cpp
@@ -184,7 +184,7 @@ void LuaContext::RunWithEnvironment(const std::string &name, const LuaEnvironmen
 
 std::shared_ptr<Registry::LuaLibrary> LuaContext::getStdLibrary(const std::string &libName)
 {
-	std::shared_ptr<LuaLibrary> foundLibrary = NULL;
+	std::shared_ptr<LuaLibrary> foundLibrary = nullptr;
 	std::unique_ptr<LuaCpp::Engine::LuaState> L = newState(globalEnvironment);
 	lua_getglobal(*L, libName.c_str());
 
@@ -247,7 +247,7 @@ std::shared_ptr<Registry::LuaLibrary> LuaContext::getStdLibrary(const std::strin
 
 std::shared_ptr<Registry::LuaCFunction> LuaContext::getBuiltInFnc(const std::string &fncName)
 {
-	std::shared_ptr<Registry::LuaCFunction> builtInFnc = NULL;
+	std::shared_ptr<Registry::LuaCFunction> builtInFnc = nullptr;
 	std::unique_ptr<LuaCpp::Engine::LuaState> L = newState(globalEnvironment);
 
 	lua_getglobal(*L, fncName.c_str());

--- a/Source/UnitTest/TestLuaCompiler.cpp
+++ b/Source/UnitTest/TestLuaCompiler.cpp
@@ -92,9 +92,9 @@ namespace LuaCpp {
 
 		std::unique_ptr<Engine::LuaState> L = ctx.newState();
 
-		EXPECT_NE((Engine::LuaState *) NULL, L.get());
+		EXPECT_NE(nullptr, L.get());
 		EXPECT_EQ(0, lua_gettop(*L));
-		EXPECT_NE((const char *) NULL, lua_pushstring(*L, "test"));
+		EXPECT_NE(nullptr, lua_pushstring(*L, "test"));
 		EXPECT_EQ(1, lua_gettop(*L));
 
 

--- a/Source/UnitTest/TestLuaContext.cpp
+++ b/Source/UnitTest/TestLuaContext.cpp
@@ -96,9 +96,9 @@ namespace LuaCpp {
 
 		std::unique_ptr<Engine::LuaState> L = ctx.newState();
 
-		EXPECT_NE((Engine::LuaState *) NULL, L.get());
+		EXPECT_NE(nullptr, L.get());
 		EXPECT_EQ(0, lua_gettop(*L));
-		EXPECT_NE((const char *) NULL, lua_pushstring(*L, "test"));
+		EXPECT_NE(nullptr, lua_pushstring(*L, "test"));
 		EXPECT_EQ(1, lua_gettop(*L));
 	}
 
@@ -119,9 +119,9 @@ namespace LuaCpp {
 
 		std::unique_ptr<Engine::LuaState> L = ctx.newState();
 
-		EXPECT_NE((Engine::LuaState *) NULL, L.get());
+		EXPECT_NE(nullptr, L.get());
 		EXPECT_EQ(0, lua_gettop(*L));
-		EXPECT_NE((const char *) NULL, lua_pushstring(*L, "test"));
+		EXPECT_NE(nullptr, lua_pushstring(*L, "test"));
 		EXPECT_EQ(1, lua_gettop(*L));
 
 		// Reuse the state
@@ -239,13 +239,13 @@ namespace LuaCpp {
 		testing::internal::CaptureStdout();
 
 		EXPECT_NO_THROW(ctx.CompileString("test", "print('Hello World from Lua, v1.0')"));
-		EXPECT_NE((Engine::LuaState *) NULL, ctx.newStateFor("test").get());
+		EXPECT_NE(nullptr, ctx.newStateFor("test").get());
 
 		EXPECT_NO_THROW(ctx.CompileString("test", "print('Hello World from Lua, v2.0')"));
-		EXPECT_NE((Engine::LuaState *) NULL, ctx.newStateFor("test").get());
+		EXPECT_NE(nullptr, ctx.newStateFor("test").get());
 	
 		EXPECT_NO_THROW(ctx.CompileString("test", "print('Hello World from Lua, v3.0')"));
-		EXPECT_NE((Engine::LuaState *) NULL, ctx.newStateFor("test").get());
+		EXPECT_NE(nullptr, ctx.newStateFor("test").get());
 		
 		EXPECT_NO_THROW(ctx.Run("test"));
 		
@@ -266,13 +266,13 @@ namespace LuaCpp {
 		testing::internal::CaptureStdout();
 
 		EXPECT_NO_THROW(ctx.CompileString("test", "print('Hello World from Lua, v1.0')", true));
-		EXPECT_NE((Engine::LuaState *) NULL, ctx.newStateFor("test").get());
+		EXPECT_NE(nullptr, ctx.newStateFor("test").get());
 
 		EXPECT_NO_THROW(ctx.CompileString("test", "print('Hello World from Lua, v2.0')", true));
-		EXPECT_NE((Engine::LuaState *) NULL, ctx.newStateFor("test").get());
+		EXPECT_NE(nullptr, ctx.newStateFor("test").get());
 	
 		EXPECT_NO_THROW(ctx.CompileString("test", "print('Hello World from Lua, v3.0')", true));
-		EXPECT_NE((Engine::LuaState *) NULL, ctx.newStateFor("test").get());
+		EXPECT_NE(nullptr, ctx.newStateFor("test").get());
 		
 		EXPECT_NO_THROW(ctx.Run("test"));
 		
@@ -320,13 +320,13 @@ namespace LuaCpp {
 		testing::internal::CaptureStdout();
 
 		EXPECT_NO_THROW(ctx.CompileFile("test", "TestLuaContext_3_v1.lua"));
-		EXPECT_NE((Engine::LuaState *) NULL, ctx.newStateFor("test").get());
+		EXPECT_NE(nullptr, ctx.newStateFor("test").get());
 
 		EXPECT_NO_THROW(ctx.CompileFile("test", "TestLuaContext_3_v2.lua"));
-		EXPECT_NE((Engine::LuaState *) NULL, ctx.newStateFor("test").get());
+		EXPECT_NE(nullptr, ctx.newStateFor("test").get());
 	
 		EXPECT_NO_THROW(ctx.CompileFile("test", "TestLuaContext_3_v3.lua"));
-		EXPECT_NE((Engine::LuaState *) NULL, ctx.newStateFor("test").get());
+		EXPECT_NE(nullptr, ctx.newStateFor("test").get());
 		
 		EXPECT_NO_THROW(ctx.Run("test"));
 		
@@ -347,13 +347,13 @@ namespace LuaCpp {
 		testing::internal::CaptureStdout();
 
 		EXPECT_NO_THROW(ctx.CompileFile("test", "TestLuaContext_3_v1.lua", true));
-		EXPECT_NE((Engine::LuaState *) NULL, ctx.newStateFor("test").get());
+		EXPECT_NE(nullptr, ctx.newStateFor("test").get());
 
 		EXPECT_NO_THROW(ctx.CompileFile("test", "TestLuaContext_3_v2.lua", true));
-		EXPECT_NE((Engine::LuaState *) NULL, ctx.newStateFor("test").get());
+		EXPECT_NE(nullptr, ctx.newStateFor("test").get());
 	
 		EXPECT_NO_THROW(ctx.CompileFile("test", "TestLuaContext_3_v3.lua", true));
-		EXPECT_NE((Engine::LuaState *) NULL, ctx.newStateFor("test").get());
+		EXPECT_NE(nullptr, ctx.newStateFor("test").get());
 		
 		EXPECT_NO_THROW(ctx.Run("test"));
 		
@@ -474,7 +474,7 @@ namespace LuaCpp {
 	
 		EXPECT_EQ("testing 1,2,3\n", output);
 		EXPECT_EQ("changed", str->getValue());
-		EXPECT_NE((void *) NULL, (void *) &ctx.getGlobalVariable("test_str"));
+		EXPECT_NE(nullptr, &ctx.getGlobalVariable("test_str"));
 		std::shared_ptr<Engine::LuaTString> str2 = std::static_pointer_cast<Engine::LuaTString>(ctx.getGlobalVariable("test_str"));
 		EXPECT_EQ("changed", str2->getValue());
 
@@ -499,7 +499,7 @@ namespace LuaCpp {
 	
 		EXPECT_EQ("testing 1,2,3\n", output);
 		EXPECT_EQ("changed", str->getValue());
-		EXPECT_EQ((void *) NULL, (void *) &(*ctx.getGlobalVariable("test_str")));
+		EXPECT_EQ(nullptr, &(*ctx.getGlobalVariable("test_str")));
 
 	}
 

--- a/Source/UnitTest/TestLuaContextNewState.cpp
+++ b/Source/UnitTest/TestLuaContextNewState.cpp
@@ -43,7 +43,7 @@ namespace LuaCpp {
 
         // Test newState() without parameters
         std::unique_ptr<Engine::LuaState> L = ctx.newState();
-        EXPECT_NE((Engine::LuaState *) NULL, L.get());
+        EXPECT_NE(nullptr, L.get());
 
         // Test newState() with environment
         LuaEnvironment env;
@@ -51,7 +51,7 @@ namespace LuaCpp {
         env["test_str"] = str;
 
         std::unique_ptr<Engine::LuaState> L2 = ctx.newState(env);
-        EXPECT_NE((Engine::LuaState *) NULL, L2.get());
+        EXPECT_NE(nullptr, L2.get());
 
         // Verify that the global variable is set in the new state
         lua_getglobal(*L2, "test_str");

--- a/Source/UnitTest/TestLuaContextNewState.cpp
+++ b/Source/UnitTest/TestLuaContextNewState.cpp
@@ -305,4 +305,14 @@ namespace LuaCpp {
         EXPECT_THROW(proxy.RunWithEnvironment(env), std::runtime_error);
     }
 
+    TEST_F(TestLuaContextNewState, TestCustomAllocatorSameSize) {
+        void *ptr = customAllocator(nullptr, nullptr, 0, 100);
+        EXPECT_NE(nullptr, ptr);
+        
+        void *same_ptr = customAllocator(nullptr, ptr, 100, 100);
+        EXPECT_EQ(ptr, same_ptr);
+        
+        customAllocator(nullptr, ptr, 100, 0);
+    }
+
 }

--- a/Source/UnitTest/TestLuaMetaObject.cpp
+++ b/Source/UnitTest/TestLuaMetaObject.cpp
@@ -100,9 +100,9 @@ namespace LuaCpp {
 		std::shared_ptr<MetaMap> mm = std::make_shared<MetaMap>();
 		std::shared_ptr<MetaMap> aa = std::make_shared<MetaMap>();
 
-		EXPECT_NE((Engine::LuaState *) NULL, L.get());
+		EXPECT_NE(nullptr, L.get());
 		EXPECT_EQ(0, lua_gettop(*L));
-		EXPECT_NE((const char *) NULL, lua_pushstring(*L, "test"));
+		EXPECT_NE(nullptr, lua_pushstring(*L, "test"));
 		EXPECT_EQ(1, lua_gettop(*L));
 
 		EXPECT_NO_THROW(ctx.AddGlobalVariable("mm", mm));

--- a/Source/UnitTest/TestLuaTypes.cpp
+++ b/Source/UnitTest/TestLuaTypes.cpp
@@ -678,6 +678,18 @@ namespace LuaCpp {
 
 	}
 
+	TEST_F(TestLuaTypes, TestLuaTTableGetValueNonExistentKey) {
+		LuaContext ctx;
+		std::unique_ptr<LuaState> L = ctx.newState();
+
+		LuaTTable tbl;
+		tbl.setValue(Table::Key(1), std::make_shared<LuaTString>("exists"));
+		tbl.setValue(Table::Key("present"), std::make_shared<LuaTString>("here"));
+
+		EXPECT_EQ(LUA_TNIL, tbl.getValue(Table::Key(999)).getTypeId());
+		EXPECT_EQ(LUA_TNIL, tbl.getValue(Table::Key("nonexistent")).getTypeId());
+	}
+
 	TEST_F(TestLuaTypes, TestLuaTUserData) {
 		/**
 		 * Basic test getting instance of the `lua_State *`

--- a/Source/UnitTest/TestLuaTypes.cpp
+++ b/Source/UnitTest/TestLuaTypes.cpp
@@ -80,9 +80,9 @@ namespace LuaCpp {
 
 		std::unique_ptr<LuaState> L = ctx.newState();
 
-		EXPECT_NE((LuaState *) NULL, L.get());
+		EXPECT_NE(nullptr, L.get());
 		EXPECT_EQ(0, lua_gettop(*L));
-		EXPECT_NE((const char *) NULL, lua_pushstring(*L, "test"));
+		EXPECT_NE(nullptr, lua_pushstring(*L, "test"));
 		EXPECT_EQ(1, lua_gettop(*L));
 	}
 
@@ -101,7 +101,7 @@ namespace LuaCpp {
 		EXPECT_EQ("nil", nil.getTypeName(*L));
 
 		// Assure the state is prepared for testing
-		EXPECT_NE((LuaState *) NULL, L.get());
+		EXPECT_NE(nullptr, L.get());
 		EXPECT_EQ(0, lua_gettop(*L));
 
 		// Assure pushing the value
@@ -116,7 +116,7 @@ namespace LuaCpp {
 		EXPECT_NO_THROW(nil.PopValue(*L, 1));
 
 		// Push new value on stacks
-		EXPECT_NE((const char *) NULL, lua_pushstring(*L, "test"));
+		EXPECT_NE(nullptr, lua_pushstring(*L, "test"));
 
 		// Assure popping the value in relative referencing
 		EXPECT_THROW(nil.PopValue(*L, -1), std::invalid_argument);
@@ -143,7 +143,7 @@ namespace LuaCpp {
 		EXPECT_EQ("string", str.getTypeName(*L));
 
 		// Assure the state is prepared for testing
-		EXPECT_NE((LuaState *) NULL, L.get());
+		EXPECT_NE(nullptr, L.get());
 		EXPECT_EQ(0, lua_gettop(*L));
 
 		// Assure pushing the value
@@ -195,7 +195,7 @@ namespace LuaCpp {
 		EXPECT_EQ("number", num.getTypeName(*L));
 
 		// Assure the state is prepared for testing
-		EXPECT_NE((LuaState *) NULL, L.get());
+		EXPECT_NE(nullptr, L.get());
 		EXPECT_EQ(0, lua_gettop(*L));
 
 		// Assure pushing the value
@@ -247,7 +247,7 @@ namespace LuaCpp {
 		EXPECT_EQ("boolean", bol.getTypeName(*L));
 
 		// Assure the state is prepared for testing
-		EXPECT_NE((LuaState *) NULL, L.get());
+		EXPECT_NE(nullptr, L.get());
 		EXPECT_EQ(0, lua_gettop(*L));
 
 		// Assure pushing the value
@@ -320,7 +320,7 @@ namespace LuaCpp {
 		EXPECT_EQ("table", tbl.getTypeName(*L));
 
 		// Assure the state is prepared for testing
-		EXPECT_NE((LuaState *) NULL, L.get());
+		EXPECT_NE(nullptr, L.get());
 		EXPECT_EQ(0, lua_gettop(*L));
 
 		// Assure pushing the value
@@ -379,7 +379,7 @@ namespace LuaCpp {
 		EXPECT_EQ("table", tbl.getTypeName(*L));
 
 		// Assure the state is prepared for testing
-		EXPECT_NE((LuaState *) NULL, L.get());
+		EXPECT_NE(nullptr, L.get());
 		EXPECT_EQ(0, lua_gettop(*L));
 
 		// Assure pushing the value
@@ -438,7 +438,7 @@ namespace LuaCpp {
 		EXPECT_EQ("table", tbl.getTypeName(*L));
 
 		// Assure the state is prepared for testing
-		EXPECT_NE((LuaState *) NULL, L.get());
+		EXPECT_NE(nullptr, L.get());
 		EXPECT_EQ(0, lua_gettop(*L));
 
 		// Assure pushing the value
@@ -693,7 +693,7 @@ namespace LuaCpp {
 		EXPECT_EQ("userdata", ud.getTypeName(*L));
 
 		// Assure the state is prepared for testing
-		EXPECT_NE((LuaState *) NULL, L.get());
+		EXPECT_NE(nullptr, L.get());
 		EXPECT_EQ(0, lua_gettop(*L));
 
 		EXPECT_EQ("userdata", ud.ToString());
@@ -702,15 +702,15 @@ namespace LuaCpp {
 		EXPECT_NO_THROW(ud.PushValue(*L));
 		EXPECT_EQ(1, lua_gettop(*L));
 		EXPECT_EQ(LUA_TUSERDATA, lua_type(*L, -1));
-		EXPECT_NE((void *) NULL, ud.getRawUserData());
+		EXPECT_NE(nullptr, ud.getRawUserData());
 
 		// Assure popping the value in relative referencing
 		EXPECT_NO_THROW(ud.PopValue(*L, -1));
-		EXPECT_NE((void *) NULL, ud.getRawUserData());
+		EXPECT_NE(nullptr, ud.getRawUserData());
 
 		// Assure pooping the value with absolute referencing
 		EXPECT_NO_THROW(ud.PopValue(*L, 1));
-		EXPECT_NE((void *) NULL, ud.getRawUserData());
+		EXPECT_NE(nullptr, ud.getRawUserData());
 
 		// Push new value on stacks
 		lua_pushnil(*L);

--- a/docs/dcp/DCP-001-bounds-checking-null-handling.md
+++ b/docs/dcp/DCP-001-bounds-checking-null-handling.md
@@ -1,0 +1,132 @@
+# DCP-001: Bounds Checking and Null Pointer Handling
+
+**Status:** Implemented  
+**Author:** Code Review  
+**Date:** 2026-02-17  
+**Type:** Bug Fix  
+
+## Summary
+
+Fix undefined behavior in `LuaTTable::getValue()` due to missing bounds checking and modernize null pointer handling by replacing deprecated `NULL` macro with `nullptr`.
+
+## Motivation
+
+### Issue 1: Bounds Checking Bug in `LuaTTable::getValue()`
+
+**Current Implementation** (`Source/Engine/LuaTTable.cpp:206-208`):
+```cpp
+LuaType &LuaTTable::getValue(Table::Key key) {
+    return *table[key];
+}
+```
+
+**Problems:**
+1. `std::map::operator[]` creates a default entry if the key doesn't exist
+2. If the key doesn't exist, `nullptr` is inserted and dereferenced → undefined behavior
+3. If the key exists with `nullptr` value → undefined behavior
+
+**Documented Behavior** (`Source/Engine/LuaTTable.hpp:181-182`):
+> "Returns the value stored at the key. If the key is not found, a nil value will be returned"
+
+Current implementation violates this contract.
+
+### Issue 2: Inconsistent Null Pointer Handling
+
+**Locations using deprecated `NULL` macro:**
+- `Source/LuaContext.cpp:187` - `std::shared_ptr<LuaLibrary> foundLibrary = NULL;`
+- `Source/LuaContext.cpp:250` - `std::shared_ptr<Registry::LuaCFunction> builtInFnc = NULL;`
+- `Source/Engine/LuaTUserData.hpp:99` - `userdata(NULL)`
+
+**Why `nullptr` is preferred (C++11+):**
+1. Type-safe: `nullptr` has type `std::nullptr_t`
+2. Avoids ambiguity with integer `0`
+3. Works correctly with template deduction
+4. Modern C++ best practice
+
+## Proposed Solution
+
+### Solution 1: Bounds Checking Fix
+
+Replace `getValue()` implementation:
+
+```cpp
+#include "LuaTNil.hpp"  // Add at top of file
+
+LuaType &LuaTTable::getValue(Table::Key key) {
+    auto it = table.find(key);
+    if (it == table.end()) {
+        static LuaTNil nilPlaceholder;
+        return nilPlaceholder;
+    }
+    return *(it->second);
+}
+```
+
+**Rationale:**
+- Uses `find()` to avoid modifying the map
+- Returns static `LuaTNil` placeholder for missing keys (matches documented behavior)
+- No dynamic allocation overhead
+- Thread-safe for read access (static initialization is thread-safe in C++11+)
+
+### Solution 2: NULL → nullptr Replacement
+
+**Source Files to Modify:**
+
+| File | Line | Current | Change To |
+|------|------|---------|-----------|
+| `Source/LuaContext.cpp` | 187 | `= NULL` | `= nullptr` |
+| `Source/LuaContext.cpp` | 250 | `= NULL` | `= nullptr` |
+| `Source/Engine/LuaTUserData.hpp` | 99 | `userdata(NULL)` | `userdata(nullptr)` |
+
+**Test Files to Update:**
+
+| File | Occurrences |
+|------|-------------|
+| `Source/UnitTest/TestLuaContext.cpp` | 18 |
+| `Source/UnitTest/TestLuaContextNewState.cpp` | 2 |
+| `Source/UnitTest/TestLuaCompiler.cpp` | 2 |
+| `Source/UnitTest/TestLuaMetaObject.cpp` | 2 |
+| `Source/UnitTest/TestLuaTypes.cpp` | 16 |
+
+**Pattern Change:**
+```cpp
+// Before
+EXPECT_NE((Engine::LuaState *) NULL, L.get());
+
+// After
+EXPECT_NE(nullptr, L.get());
+```
+
+**Files NOT to Modify (C API requires NULL):**
+- `Source/Registry/LuaLibrary.cpp:136-137,162-163` - `luaL_Reg` struct sentinel values
+- `Source/Registry/LuaCodeSnippet.cpp:61` - `lua_load()` C API parameter
+
+## Impact Analysis
+
+### API Compatibility
+- **Breaking:** No - return type and semantics unchanged
+- **Behavior Change:** Yes - missing keys now return nil instead of UB
+
+### Performance
+- No significant performance impact
+- `find()` is O(log n), same as `operator[]`
+- Avoids unnecessary map insertion
+
+### Testing
+- Existing tests should pass unchanged
+- No new tests required (behavior now matches documentation)
+- Memory tests (`make test_memory`) should show no regressions
+
+## Implementation Checklist
+
+- [x] Modify `Source/Engine/LuaTTable.cpp` - fix `getValue()`
+- [x] Modify `Source/LuaContext.cpp` - replace NULL with nullptr
+- [x] Modify `Source/Engine/LuaTUserData.hpp` - replace NULL with nullptr
+- [x] Update test files for NULL → nullptr consistency
+- [x] Run `make test` to verify no regressions
+- [x] Run `make test_memory` to verify no memory leaks
+
+## References
+
+- C++ Core Guidelines: [ES.47: Use nullptr rather than 0 or NULL](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es47-use-nullptr-rather-than-0-or-null)
+- `std::map::operator[]` documentation: inserts default-constructed element if key not found


### PR DESCRIPTION
## PR Type
- [x] Bug fix (non-breaking change which fixes an issue)

## Summary
- Fix undefined behavior in `LuaTTable::getValue()` where missing keys would insert nullptr and cause UB on dereference
- Replace deprecated `NULL` macro with `nullptr` for C++11+ type safety
- Add DCP-001 design change proposal document

## How Has This Been Tested
- All 73 unit tests pass
- Build successful with Debug configuration

## Checklist
- [x] My code follows the code style of this project
- [x] All new and existing tests passed